### PR TITLE
ES.61 clarify Enforcement wording

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -12474,7 +12474,7 @@ Flag naked `new`s and naked `delete`s.
 
 ##### Reason
 
-That's what the language requires and mistakes can lead to resource release errors and/or memory corruption.
+That's what the language requires, and mismatches can lead to resource release errors and/or memory corruption.
 
 ##### Example, bad
 
@@ -12491,8 +12491,8 @@ This example not only violates the [no naked `new` rule](#Res-new) as in the pre
 
 ##### Enforcement
 
-* If the `new` and the `delete` are in the same scope, mistakes can be flagged.
-* If the `new` and the `delete` are in a constructor/destructor pair, mistakes can be flagged.
+* Flag mismatched `new` and `delete` if they are in the same scope.
+* Flag mismatched `new` and `delete` if they are in a constructor/destructor pair.
 
 ### <a name="Res-arr2"></a>ES.62: Don't compare pointers into different arrays
 


### PR DESCRIPTION
The original text was "If the `new` and the `delete` are in the same scope, mistakes can be flagged." This has been [misinterpreted](https://stackoverflow.com/q/75905524) to mean "Any `new` and `delete` in the same scope is a mistake and should be flagged."

Reword the Enforcement clauses to follow the pattern established by the other Enforcement clauses: "Flag (bad thing)". Also, call the issue a "mismatch" rather than a "mistake", so that it is more clear that the underlying issue is the mismatch between scalar and array new/deletion.